### PR TITLE
Updated the iOS and MacOS applications to use language version 'Swift 5'

### DIFF
--- a/Example/ExampleApp_iOS/AppDelegate.swift
+++ b/Example/ExampleApp_iOS/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/Example/ExampleApp_iOS/ViewController.swift
+++ b/Example/ExampleApp_iOS/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController {
         do {
             let gmTileOverlay = try GoogleMapsTileOverlay(jsonURL: jsonURL)
             gmTileOverlay.canReplaceMapContent = true
-            mapView.add(gmTileOverlay)
+            mapView.addOverlay(gmTileOverlay)
         } catch let error {
             print(error.localizedDescription)
         }

--- a/ExampleApp_macOS/ViewController.swift
+++ b/ExampleApp_macOS/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: NSViewController {
         do {
             let gmTileOverlay = try GoogleMapsTileOverlay(jsonURL: jsonURL)
             gmTileOverlay.canReplaceMapContent = true
-            mapView.add(gmTileOverlay)
+            mapView.addOverlay(gmTileOverlay)
         } catch let error {
             print(error.localizedDescription)
         }

--- a/GoogleMapsTileOverlay.xcodeproj/project.pbxproj
+++ b/GoogleMapsTileOverlay.xcodeproj/project.pbxproj
@@ -543,12 +543,16 @@
 					};
 					5C3E508420ECC3F300676BF7 = {
 						CreatedOnToolsVersion = 9.3.1;
+						LastSwiftMigration = 1030;
 					};
 					5C3E508D20ECC3F300676BF7 = {
 						CreatedOnToolsVersion = 9.3.1;
+						LastSwiftMigration = 1030;
+						TestTargetID = 5C3E50A820ECC5D800676BF7;
 					};
 					5C3E50A820ECC5D800676BF7 = {
 						CreatedOnToolsVersion = 9.3.1;
+						LastSwiftMigration = 1030;
 					};
 					5CAED97020F4C0DD00FAF0F4 = {
 						CreatedOnToolsVersion = 9.4.1;
@@ -815,7 +819,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
@@ -843,7 +847,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
 			};
@@ -865,7 +869,7 @@
 				PRODUCT_MODULE_NAME = GoogleMapsTileOverlay_tvOS_Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.4;
 			};
@@ -887,7 +891,7 @@
 				PRODUCT_MODULE_NAME = GoogleMapsTileOverlay_tvOS_Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 11.4;
 			};
@@ -1036,7 +1040,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1063,7 +1067,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1083,8 +1087,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.thepeaklab.GoogleMapsTileOverlayTests;
 				PRODUCT_MODULE_NAME = GoogleMapsTileOverlay_iOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ExampleApp_iOS.app/ExampleApp_iOS";
 			};
 			name = Debug;
 		};
@@ -1103,8 +1108,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.thepeaklab.GoogleMapsTileOverlayTests;
 				PRODUCT_MODULE_NAME = GoogleMapsTileOverlay_iOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ExampleApp_iOS.app/ExampleApp_iOS";
 			};
 			name = Release;
 		};
@@ -1123,7 +1129,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thepeaklab.ExampleApp-iOS";
 				PRODUCT_MODULE_NAME = GoogleMapsTileOverlay_ExampleApp_iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1143,7 +1149,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thepeaklab.ExampleApp-iOS";
 				PRODUCT_MODULE_NAME = GoogleMapsTileOverlay_ExampleApp_iOS;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -1151,11 +1157,11 @@
 		5CAED97620F4C0DE00FAF0F4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VK98J66HQM;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1172,18 +1178,18 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		5CAED97720F4C0DE00FAF0F4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = VK98J66HQM;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1200,7 +1206,7 @@
 				PRODUCT_NAME = "$(PROJECT_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1210,10 +1216,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ExampleApp_macOS/ExampleApp_macOS.entitlements;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = VK98J66HQM;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ExampleApp_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1223,7 +1229,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thepeaklab.ExampleApp-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1233,10 +1239,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = ExampleApp_macOS/ExampleApp_macOS.entitlements;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = VK98J66HQM;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = ExampleApp_macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1246,7 +1252,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.thepeaklab.ExampleApp-macOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
- Fixed up minor issues in AppDelegate and ViewController files in test projects.
- re-enabled tests for iOS test project and ensured that it runs and tests correctly, 
   - however this is in ignored scheme files so will not be checked in.
   - Test target for iOS is now set to be hosted in the iOS app.
- Changed signing for MacOS project to be generic Ad-Hoc so that it builds and runs without provisioning and without original authors ID in target. Ensured MacOS app runs correctly.

Due to lack of an AppleTV, was unable to test on one.